### PR TITLE
gh: sort prs by repo

### DIFF
--- a/gh.go
+++ b/gh.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 )
@@ -137,6 +138,10 @@ func GHGetPulls(user string) ([]GHOpenPR, error) {
 			url:    node.URL,
 		})
 	}
+
+	sort.Slice(prs, func(i, j int) bool {
+		return prs[i].repo <= prs[j].repo
+	})
 
 	return prs, nil
 }


### PR DESCRIPTION
What
-----

Sort the results by repo name

Why
----

Grouping them results in better UX

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/1482692/193359093-5bd83168-6973-4898-ba3d-cf2ec5d79f0f.png">
